### PR TITLE
new http endpoint for package download

### DIFF
--- a/core/src/main/scala/org/genivi/sota/core/transfer/PackageDownloadProcess.scala
+++ b/core/src/main/scala/org/genivi/sota/core/transfer/PackageDownloadProcess.scala
@@ -1,0 +1,74 @@
+package org.genivi.sota.core.transfer
+
+import java.io.File
+import java.net.URI
+import java.util.UUID
+
+import akka.http.scaladsl.model._
+import akka.stream.io.SynchronousFileSource
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.string.Uuid
+import org.genivi.sota.core.data.{Package, UpdateStatus, Vehicle}
+import org.genivi.sota.core.db.Packages
+import org.genivi.sota.core.db.UpdateSpecs._
+import org.genivi.sota.db.SlickExtensions
+import org.genivi.sota.refined.SlickRefined._
+import slick.driver.MySQLDriver.api._
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.language.implicitConversions
+
+
+class PackageDownloadProcess(db: Database) {
+  import SlickExtensions._
+
+  private implicit def uuidToJava(refined: Refined[String, Uuid]): Rep[UUID] =
+    UUID.fromString(refined.get).bind
+
+  def buildClientDownloadResponse(uuid: Refined[String, Uuid])(implicit ec: ExecutionContext): Future[HttpResponse] = {
+    val availablePackageIO = findForDownload(uuid)
+
+    db.run(availablePackageIO).map {
+      case Some(packageModel) ⇒
+        val entity = fileEntity(packageModel)
+        HttpResponse(StatusCodes.OK, entity = entity)
+      case None ⇒
+        HttpResponse(StatusCodes.NotFound, entity = "Package not found")
+    }
+  }
+
+  def buildClientPendingIdsResponse(vin: Vehicle.Vin)
+                                   (implicit ec: ExecutionContext) : Future[Seq[UUID]] = {
+    db.run(findPendingPackageIdsFor(vin))
+  }
+
+  private def findPendingPackageIdsFor(vin: Vehicle.Vin)
+                              (implicit ec: ExecutionContext) : DBIO[Seq[UUID]] = {
+    updateSpecs
+      .filter(r => r.vin === vin)
+      .filter(_.status.inSet(List(UpdateStatus.InFlight, UpdateStatus.Pending)))
+      .map(_.requestId)
+      .result
+  }
+
+  private def findPackagesWith(updateRequestId: Refined[String, Uuid]): DBIO[Seq[Package]] = {
+    updateRequests
+      .filter(_.id === updateRequestId)
+      .join(Packages.packages)
+      .on((updateRequest, packageM) ⇒
+        packageM.name === updateRequest.packageName && packageM.version === updateRequest.packageVersion)
+      .map { case (_, packageM) ⇒ packageM }
+      .result
+  }
+
+  private def findForDownload(updateRequestId: Refined[String, Uuid])(implicit ec: ExecutionContext): DBIO[Option[Package]] = {
+    findPackagesWith(updateRequestId).map(_.headOption)
+  }
+
+  private def fileEntity(packageModel: Package): UniversalEntity = {
+    val file = new File(new URI(packageModel.uri.toString()))
+    val size = file.length()
+    val source = SynchronousFileSource(file)
+    HttpEntity(MediaTypes.`application/octet-stream`, size, source)
+  }
+}

--- a/core/src/test/scala/org/genivi/sota/core/TestDatabase.scala
+++ b/core/src/test/scala/org/genivi/sota/core/TestDatabase.scala
@@ -6,6 +6,8 @@ package org.genivi.sota.core
 
 import com.typesafe.config.ConfigFactory
 import org.flywaydb.core.Flyway
+import org.scalatest.{Suite, BeforeAndAfterAll}
+import slick.driver.MySQLDriver.api._
 
 /*
  * Helper object to configure test database for specs
@@ -23,5 +25,23 @@ object TestDatabase {
     flyway.setLocations("classpath:db.migration")
     flyway.clean()
     flyway.migrate()
+  }
+}
+
+trait DatabaseSpec extends BeforeAndAfterAll {
+  self: Suite ⇒
+
+  private val databaseId = "test-database"
+
+  lazy val db = Database.forConfig(databaseId)
+
+  override def beforeAll() {
+    TestDatabase.resetDatabase(databaseId)
+    super.beforeAll()
+  }
+
+  override def afterAll() {
+    db.close()
+    super.afterAll()
   }
 }

--- a/core/src/test/scala/org/genivi/sota/core/UpdateRequestSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/UpdateRequestSpec.scala
@@ -61,6 +61,7 @@ class UpdateRequestSpec extends PropSpec with PropertyChecks with Matchers with 
   property("Update requests can be listed")  {
     new Service() {
       forAll(Gen.listOf(updateRequestGen(PackageIdGen))) { (requests: Seq[UpdateRequest]) =>
+        // TODO: I don't think this test is running, we just create a future and never wait for it's result
         Future.sequence(requests.map(r => db.run(UpdateRequests.persist(r)))).map { _ =>
           Get( Uri(path = UpdatesPath) ) ~> resource.route ~> check {
             status shouldBe StatusCodes.OK

--- a/core/src/test/scala/org/genivi/sota/core/transfer/PackageDownloadProcessSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/transfer/PackageDownloadProcessSpec.scala
@@ -1,0 +1,25 @@
+package org.genivi.sota.core.transfer
+
+import org.genivi.sota.core.DatabaseSpec
+import org.genivi.sota.core.data.Vehicle
+import org.scalatest._
+import org.scalatest.concurrent.ScalaFutures
+
+class PackageDownloadProcessSpec extends FunSuite
+  with ShouldMatchers
+  with DatabaseSpec
+  with ScalaFutures {
+
+  implicit val ec = scala.concurrent.ExecutionContext.global
+
+  val packageDownloadProcess = new PackageDownloadProcess(db)
+
+  test("builds a response with an empty list if there are no pending updates for a vehile") {
+    val vin = Vehicle.genVin.sample.get
+    val pendingIdsResponse = packageDownloadProcess.buildClientPendingIdsResponse(vin)
+
+    whenReady(pendingIdsResponse) { uuids ⇒
+      uuids shouldBe empty
+    }
+  }
+}

--- a/project/SotaBuild.scala
+++ b/project/SotaBuild.scala
@@ -133,15 +133,17 @@ object Dependencies {
 
   val AkkaHttpVersion = "1.0"
 
+  val AkkaStreamVersion = AkkaHttpVersion
+
   val AkkaVersion = "2.4.0"
 
   val CirceVersion = "0.2.0"
-
 
   lazy val Akka = Seq(
     "com.typesafe.akka" % "akka-http-core-experimental_2.11" % AkkaHttpVersion,
     "com.typesafe.akka" % "akka-http-experimental_2.11" % AkkaHttpVersion,
     "com.typesafe.akka" %% "akka-http-testkit-experimental" % AkkaHttpVersion,
+    "com.typesafe.akka" %% "akka-stream-experimental" % AkkaStreamVersion,
     "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
     "ch.qos.logback" % "logback-classic" % "1.0.13"
   )


### PR DESCRIPTION
Implement new http endpoint to allow client to download package through http bypassing rvi.

There are two new endpoints:
- GET on `/vehicles/:vin/updates` - Returns a list of update request
  UUIDs for packages that were not still installed by the client.
- GET `/vehicles/:vin/updates/:request_id/download` - Returns the
  package data corresponding to `request_id` in a binary
  format. `request_id` should be obtained using `/updates`. This
  endpoint supports partial content download using Http Range Requests [1](https://tools.ietf.org/html/rfc7233)
