### PR TITLE
upgrade to Flyway 4.0.1

### DIFF
--- a/project/SotaBuild.scala
+++ b/project/SotaBuild.scala
@@ -222,7 +222,7 @@ object Dependencies {
 
   lazy val ScalaCheck = "org.scalacheck" %% "scalacheck" % "1.12.4" % "test"
 
-  lazy val Flyway = "org.flywaydb" % "flyway-core" % "3.2.1"
+  lazy val Flyway = "org.flywaydb" % "flyway-core" % "4.0.1"
 
   lazy val TestFrameworks = Seq( ScalaTest, ScalaCheck )
 


### PR DESCRIPTION
- Flyway 4.0.1 got (slightly) more helpful when computing checksums, https://github.com/flyway/flyway/issues/253
- and also:

> This version comes with a new metadata table format. 
> Migration is transparent and automatic on first run of any Flyway command. 
> This new format is not compatible with older Flyway versions.

We're upgrading from Flyway 3.2.1. Release notes: https://flywaydb.org/documentation/releaseNotes

/cc @simao The CI build for PR uses an empty database on which most migrations succeed. Instead, a database with all tables populated would catch migration errors before they reach production servers.
