### PR TITLE
README: Adjust link to GENIVI documentation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project is the top-level git repository for the GENIVI SOTA project.
 
-Please refer to [the documentation](http://advancedtelematic.github.io/rvi_sota_server/) for more information.
+Please refer to [the documentation](http://genivi.github.io/rvi_sota_server/) for more information.
 
 ## Running tests
 


### PR DESCRIPTION
Correct the link to documentation to point to
http://genivi.github.io/rvi_sota_server/
instead than the page from ATS.

Signed-off-by: Gianpaolo Macario gianpaolo_macario@mentor.com
